### PR TITLE
fix: replace retired VS Marketplace badges with self-hosted endpoint badges

### DIFF
--- a/.github/scripts/fetch-extension-stats.js
+++ b/.github/scripts/fetch-extension-stats.js
@@ -1,0 +1,127 @@
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+const BADGES_DIR = path.resolve(__dirname, '../../badges');
+
+const EXTENSIONS = [
+  {
+    id: 'jeffreybulanadi.bc-docker-manager',
+    slug: 'bc-docker-manager',
+    versionColor: '0078d7',
+    installColor: '63ba83',
+  },
+  {
+    id: 'jeffreybulanadi.al-indent-prism',
+    slug: 'al-indent-prism',
+    versionColor: '0066CC',
+    installColor: '63ba83',
+  },
+];
+
+function queryMarketplace(extensionId) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({
+      filters: [{ criteria: [{ filterType: 7, value: extensionId }] }],
+      flags: 769, // IncludeVersions(1) | IncludeStatistics(256) | IncludeLatestVersionOnly(512)
+    });
+
+    const req = https.request(
+      {
+        hostname: 'marketplace.visualstudio.com',
+        path: '/_apis/public/gallery/extensionquery',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json;api-version=3.0-preview.1',
+          'Content-Length': Buffer.byteLength(body),
+          'User-Agent': 'Mozilla/5.0 (compatible; GitHubActions/badge-updater)',
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => (raw += chunk));
+        res.on('end', () => {
+          if (res.statusCode !== 200) {
+            return reject(new Error(`Marketplace API returned HTTP ${res.statusCode}`));
+          }
+          try {
+            resolve(JSON.parse(raw));
+          } catch (e) {
+            reject(new Error(`Failed to parse Marketplace response: ${e.message}`));
+          }
+        });
+      }
+    );
+
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function writeBadge(filePath, label, message, color) {
+  const content = JSON.stringify({ schemaVersion: 1, label, message, color }, null, 2);
+  fs.writeFileSync(filePath, content + '\n');
+}
+
+(async () => {
+  fs.mkdirSync(BADGES_DIR, { recursive: true });
+
+  let hasError = false;
+
+  for (const ext of EXTENSIONS) {
+    try {
+      const data = await queryMarketplace(ext.id);
+      const extension = data.results?.[0]?.extensions?.[0];
+
+      if (!extension) {
+        throw new Error(`Extension not found in response: ${ext.id}`);
+      }
+
+      const version = extension.versions?.[0]?.version ?? 'unknown';
+
+      const statsMap = {};
+      for (const s of extension.statistics ?? []) {
+        statsMap[s.statisticName] = s.value;
+      }
+
+      const installs = Math.round(statsMap.install ?? 0);
+      const avgRating = statsMap.averagerating != null
+        ? Number(statsMap.averagerating).toFixed(1)
+        : '0.0';
+      const ratingCount = Math.round(statsMap.ratingcount ?? 0);
+
+      writeBadge(
+        path.join(BADGES_DIR, `${ext.slug}-version.json`),
+        'version',
+        `v${version}`,
+        ext.versionColor
+      );
+      writeBadge(
+        path.join(BADGES_DIR, `${ext.slug}-installs.json`),
+        'installs',
+        installs.toLocaleString(),
+        ext.installColor
+      );
+      writeBadge(
+        path.join(BADGES_DIR, `${ext.slug}-rating.json`),
+        'rating',
+        `${avgRating}/5 (${ratingCount})`,
+        'FFD700'
+      );
+
+      console.log(`${ext.id}: v${version}, ${installs} installs, ${avgRating}/5 (${ratingCount} ratings)`);
+    } catch (err) {
+      console.error(`ERROR fetching stats for ${ext.id}: ${err.message}`);
+      console.error('Existing badge files will be preserved.');
+      hasError = true;
+    }
+  }
+
+  if (hasError) {
+    process.exit(1);
+  }
+
+  console.log('All badge JSON files updated.');
+})();

--- a/.github/workflows/generate-extension-screenshots.yml
+++ b/.github/workflows/generate-extension-screenshots.yml
@@ -31,6 +31,10 @@ jobs:
         run: node screenshot-extensions.js
         working-directory: .github/scripts
 
+      - name: Fetch extension stats (installs, version, rating)
+        run: node fetch-extension-stats.js
+        working-directory: .github/scripts
+
       - name: Install ImageMagick
         run: sudo apt-get install -y imagemagick
 
@@ -53,7 +57,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add images/ext-bc-docker-manager.png \
                   images/ext-al-indent-prism.png \
-                  images/extensions-showcase.gif
+                  images/extensions-showcase.gif \
+                  badges/
           git diff --cached --quiet \
-            || git commit -m "chore: refresh extension marketplace screenshots" \
+            || git commit -m "chore: refresh extension screenshots and stats" \
             && git push

--- a/README.md
+++ b/README.md
@@ -23,14 +23,16 @@
 </div>
 
 **[BC Docker Manager](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.bc-docker-manager)**  
-[![Version](https://img.shields.io/visual-studio-marketplace/v/jeffreybulanadi.bc-docker-manager?label=version&style=flat-square&color=0078d7)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.bc-docker-manager)
-[![Installs](https://img.shields.io/visual-studio-marketplace/i/jeffreybulanadi.bc-docker-manager?style=flat-square&color=63ba83)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.bc-docker-manager)
+[![Version](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jeffreybulanadi/jeffreybulanadi/main/badges/bc-docker-manager-version.json&style=flat-square)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.bc-docker-manager)
+[![Installs](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jeffreybulanadi/jeffreybulanadi/main/badges/bc-docker-manager-installs.json&style=flat-square)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.bc-docker-manager)
+[![Rating](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jeffreybulanadi/jeffreybulanadi/main/badges/bc-docker-manager-rating.json&style=flat-square)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.bc-docker-manager)
 
 A lightweight, all-in-one control center for Business Central Docker development inside VS Code. Browse artifacts, create containers, manage environments, and develop AL apps without BcContainerHelper or Docker Desktop.
 
 **[AL Indent Prism](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.al-indent-prism)**  
-[![Version](https://img.shields.io/visual-studio-marketplace/v/jeffreybulanadi.al-indent-prism?label=version&style=flat-square&color=0066CC)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.al-indent-prism)
-[![Installs](https://img.shields.io/visual-studio-marketplace/i/jeffreybulanadi.al-indent-prism?style=flat-square&color=63ba83)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.al-indent-prism)
+[![Version](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jeffreybulanadi/jeffreybulanadi/main/badges/al-indent-prism-version.json&style=flat-square)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.al-indent-prism)
+[![Installs](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jeffreybulanadi/jeffreybulanadi/main/badges/al-indent-prism-installs.json&style=flat-square)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.al-indent-prism)
+[![Rating](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jeffreybulanadi/jeffreybulanadi/main/badges/al-indent-prism-rating.json&style=flat-square)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.al-indent-prism)
 
 Rainbow indentation colorizer for Business Central AL files. Lightweight, real-time, and fully configurable. Makes nested AL code actually readable.
 

--- a/badges/al-indent-prism-installs.json
+++ b/badges/al-indent-prism-installs.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "installs",
+  "message": "336",
+  "color": "63ba83"
+}

--- a/badges/al-indent-prism-rating.json
+++ b/badges/al-indent-prism-rating.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "rating",
+  "message": "5.0/5 (5)",
+  "color": "FFD700"
+}

--- a/badges/al-indent-prism-version.json
+++ b/badges/al-indent-prism-version.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "v1.0.3",
+  "color": "0066CC"
+}

--- a/badges/bc-docker-manager-installs.json
+++ b/badges/bc-docker-manager-installs.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "installs",
+  "message": "213",
+  "color": "63ba83"
+}

--- a/badges/bc-docker-manager-rating.json
+++ b/badges/bc-docker-manager-rating.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "rating",
+  "message": "5.0/5 (2)",
+  "color": "FFD700"
+}

--- a/badges/bc-docker-manager-version.json
+++ b/badges/bc-docker-manager-version.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "v1.1.0",
+  "color": "0078d7"
+}


### PR DESCRIPTION
Fixes the retired shields.io Visual Studio Marketplace badge endpoint.

All img.shields.io/visual-studio-marketplace/* badges now show "retired badge" (shields.io permanently killed the endpoint). This replaces them with a self-hosted approach that we fully control.

Changes:

- adges/ directory added, 6 JSON files (version, installs, rating for each extension)
- .github/scripts/fetch-extension-stats.js queries VS Marketplace public API daily
- generate-extension-screenshots.yml runs the stats script and commits adges/
- README swaps all dead shields.io marketplace URLs for shields.io/endpoint URLs pointing to those JSON files
- Rating badge added (was missing before)
- On API error the existing JSON files are preserved (no data loss)
