### PR TITLE
feat: add VSCode Aquarium to extension showcase

### DIFF
--- a/.github/scripts/fetch-extension-stats.js
+++ b/.github/scripts/fetch-extension-stats.js
@@ -17,6 +17,12 @@ const EXTENSIONS = [
     versionColor: '0066CC',
     installColor: '63ba83',
   },
+  {
+    id: 'jeffreybulanadi.vscodeaquarium',
+    slug: 'vscodeaquarium',
+    versionColor: '00ACC1',
+    installColor: '63ba83',
+  },
 ];
 
 function queryMarketplace(extensionId) {

--- a/.github/scripts/screenshot-extensions.js
+++ b/.github/scripts/screenshot-extensions.js
@@ -15,6 +15,11 @@ const EXTENSIONS = [
     output: 'ext-al-indent-prism.png',
     name: 'AL Indent Prism',
   },
+  {
+    url: 'https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.vscodeaquarium',
+    output: 'ext-vscodeaquarium.png',
+    name: 'VSCode Aquarium',
+  },
 ];
 
 // Full-width clip of the page top: captures the VS Marketplace nav bar,

--- a/.github/workflows/generate-extension-screenshots.yml
+++ b/.github/workflows/generate-extension-screenshots.yml
@@ -42,7 +42,8 @@ jobs:
         run: |
           convert \
             -delay 400 images/ext-bc-docker-manager.png \
-            -delay 350 images/ext-al-indent-prism.png \
+            -delay 400 images/ext-al-indent-prism.png \
+            -delay 400 images/ext-vscodeaquarium.png \
             -loop 0 \
             -resize 900x \
             -dither Riemersma \
@@ -57,6 +58,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add images/ext-bc-docker-manager.png \
                   images/ext-al-indent-prism.png \
+                  images/ext-vscodeaquarium.png \
                   images/extensions-showcase.gif \
                   badges/
           git diff --cached --quiet \

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ A lightweight, all-in-one control center for Business Central Docker development
 
 Rainbow indentation colorizer for Business Central AL files. Lightweight, real-time, and fully configurable. Makes nested AL code actually readable.
 
+**[VSCode Aquarium](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.vscodeaquarium)**  
+[![Version](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jeffreybulanadi/jeffreybulanadi/main/badges/vscodeaquarium-version.json&style=flat-square)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.vscodeaquarium)
+[![Installs](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jeffreybulanadi/jeffreybulanadi/main/badges/vscodeaquarium-installs.json&style=flat-square)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.vscodeaquarium)
+[![Rating](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jeffreybulanadi/jeffreybulanadi/main/badges/vscodeaquarium-rating.json&style=flat-square)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.vscodeaquarium)
+
+A living freshwater aquarium inside VS Code. Nineteen sprite-animated species swim, school, grow hungry, and hunt each other in real time while you code.
+
 ---
 
 ### Writing

--- a/badges/vscodeaquarium-installs.json
+++ b/badges/vscodeaquarium-installs.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "installs",
+  "message": "174",
+  "color": "63ba83"
+}

--- a/badges/vscodeaquarium-rating.json
+++ b/badges/vscodeaquarium-rating.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "rating",
+  "message": "5.0/5 (1)",
+  "color": "FFD700"
+}

--- a/badges/vscodeaquarium-version.json
+++ b/badges/vscodeaquarium-version.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "v1.5.5",
+  "color": "00ACC1"
+}


### PR DESCRIPTION
Adds VSCode Aquarium to the Built and Shipped section of the profile README.

Changes:

- README: new entry for VSCode Aquarium with version, installs, and rating badges
- badges/vscodeaquarium-*.json: 3 new badge JSON files seeded with live data (v1.5.5, 174 installs, 5.0/5)
- fetch-extension-stats.js: vscodeaquarium added to EXTENSIONS array so stats refresh daily
- screenshot-extensions.js: vscodeaquarium added so a header screenshot is captured daily
- generate-extension-screenshots.yml: ext-vscodeaquarium.png added to GIF conversion and git commit step, delay normalised to 400cs for all 3 frames
