### PR TITLE
feat: add AL Packagist to extension showcase

### DIFF
--- a/.github/scripts/fetch-extension-stats.js
+++ b/.github/scripts/fetch-extension-stats.js
@@ -23,6 +23,12 @@ const EXTENSIONS = [
     versionColor: '00ACC1',
     installColor: '63ba83',
   },
+  {
+    id: 'jeffreybulanadi.al-packagist',
+    slug: 'al-packagist',
+    versionColor: '7C3AED',
+    installColor: '63ba83',
+  },
 ];
 
 function queryMarketplace(extensionId) {

--- a/.github/scripts/screenshot-extensions.js
+++ b/.github/scripts/screenshot-extensions.js
@@ -20,6 +20,11 @@ const EXTENSIONS = [
     output: 'ext-vscodeaquarium.png',
     name: 'VSCode Aquarium',
   },
+  {
+    url: 'https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.al-packagist',
+    output: 'ext-al-packagist.png',
+    name: 'AL Packagist',
+  },
 ];
 
 // Full-width clip of the page top: captures the VS Marketplace nav bar,

--- a/.github/workflows/generate-extension-screenshots.yml
+++ b/.github/workflows/generate-extension-screenshots.yml
@@ -44,6 +44,7 @@ jobs:
             -delay 400 images/ext-bc-docker-manager.png \
             -delay 400 images/ext-al-indent-prism.png \
             -delay 400 images/ext-vscodeaquarium.png \
+            -delay 400 images/ext-al-packagist.png \
             -loop 0 \
             -resize 900x \
             -dither Riemersma \
@@ -59,6 +60,7 @@ jobs:
           git add images/ext-bc-docker-manager.png \
                   images/ext-al-indent-prism.png \
                   images/ext-vscodeaquarium.png \
+                  images/ext-al-packagist.png \
                   images/extensions-showcase.gif \
                   badges/
           git diff --cached --quiet \

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Rainbow indentation colorizer for Business Central AL files. Lightweight, real-t
 
 A living freshwater aquarium inside VS Code. Nineteen sprite-animated species swim, school, grow hungry, and hunt each other in real time while you code.
 
+**[AL Packagist](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.al-packagist)**  
+[![Version](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jeffreybulanadi/jeffreybulanadi/main/badges/al-packagist-version.json&style=flat-square)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.al-packagist)
+[![Installs](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jeffreybulanadi/jeffreybulanadi/main/badges/al-packagist-installs.json&style=flat-square)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.al-packagist)
+[![Rating](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jeffreybulanadi/jeffreybulanadi/main/badges/al-packagist-rating.json&style=flat-square)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.al-packagist)
+
+Browse, search, and install Business Central NuGet symbol packages without leaving VS Code. Resolves packages to the BC version in your app.json, supports 40+ localizations, and works with custom NuGet V3 feeds alongside Microsoft and AppSource.
+
 ---
 
 ### Writing

--- a/badges/al-packagist-installs.json
+++ b/badges/al-packagist-installs.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "installs",
+  "message": "40",
+  "color": "63ba83"
+}

--- a/badges/al-packagist-rating.json
+++ b/badges/al-packagist-rating.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "rating",
+  "message": "5.0/5 (1)",
+  "color": "FFD700"
+}

--- a/badges/al-packagist-version.json
+++ b/badges/al-packagist-version.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "version",
+  "message": "v1.1.1",
+  "color": "7C3AED"
+}


### PR DESCRIPTION
Adds AL Packagist to the Built and Shipped section of the profile README.

Changes:

- README: new extension entry after VSCode Aquarium with version, installs, and rating badges
- badges/al-packagist-*.json: 3 new badge JSON files seeded with live data (v1.1.1, 40 installs, 5.0/5)
- fetch-extension-stats.js: al-packagist added to EXTENSIONS array for daily stats refresh
- screenshot-extensions.js: al-packagist added so ext-al-packagist.png is captured daily
- generate-extension-screenshots.yml: new PNG added to GIF conversion and git commit step (now 4 frames at 400cs each)
